### PR TITLE
feat: replace axios with undici, allow the user to provide custom HTTP client implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,8 @@
 
 JavaScript client library for connecting to and querying Apache Pinot :wine_glass:, a realtime distributed OLAP datastore.
 
+[GitHub Repo](https://github.com/kffl/pinot-client-node), [TypeDoc Reference](https://kffl.github.io/pinot-client-node/), [npm Package](https://www.npmjs.com/package/pinot-client)
+
 ## Features
 
 -   Implements a controller-based broker selector that periodically updates the table-to-broker mapping via the controller API.
@@ -92,6 +94,7 @@ UA      7457
 
 -   `logger`: a logger instance conforming to the standard Log4j interface w/ .child() method (i.e. pino, winston or log4js)
 -   `brokerReqHeaders`: additional HTTP headers (object key: value) to include in broker query API requests
+-   `customHttpClient`: a custom HTTP client implementation
 
 on top of that, `ConnectionFactory.fromController()` options may include two additional keys:
 
@@ -128,4 +131,31 @@ const options = {
 };
 
 const connection = await ConnectionFactory.fromController("localhost:9000", options);
+```
+
+### Using a custom HTTP client
+
+By default `pinot-client` uses `undici` for performing HTTP requests against Pinot Borkers and Controllers. A custom `HttpClient` interface implementation (containing POST and GET methods) can be provided instead via the `customHttpClient` options key:
+
+```typescript
+
+const myClient: HttpClient = {
+    get: async function <T>(url: string, options: { headers: Record<string, string> }) {
+        const { statusCode, parsedBody } = await otherHTTPClientLib<T>(url, ...);
+        // data is of type T
+        return { status: statusCode, data: parsedBody };
+    },
+    post: async function <T>(url: string, data: object, options: { headers: Record<string, string> }) {
+        const { statusCode, parsedBody } = await otherHTTPClientLib<T>(url, ...);
+        // data is of type T
+        return { status: statusCode, data: parsedBody };
+    },
+};
+
+const options = {
+    customHttpClient: myClient,
+}
+
+const c = await ConnectionFactory.fromController("http://localhost:9000", options);
+
 ```

--- a/package.json
+++ b/package.json
@@ -36,6 +36,6 @@
         "typescript": "^4.7.2"
     },
     "dependencies": {
-        "axios": "^0.27.2"
+        "undici": "^5.8.0"
     }
 }

--- a/src/connection-factory.spec.ts
+++ b/src/connection-factory.spec.ts
@@ -8,11 +8,8 @@ describe("ConnectionFactory", () => {
     let controllerTestServer;
     const controllerHandlerHeaders = jest.fn();
 
-    beforeEach(async () => {
-        brokerHandlerBody.mockClear();
-        brokerHandlerHeaders.mockClear();
-        controllerHandlerHeaders.mockClear();
-        brokerTestServer = fastify();
+    beforeAll(async () => {
+        brokerTestServer = fastify({ forceCloseConnections: true });
         brokerTestServer.post("/query/sql", (req, res) => {
             brokerHandlerBody(req.body);
             brokerHandlerHeaders(req.headers);
@@ -23,7 +20,7 @@ describe("ConnectionFactory", () => {
         });
         await brokerTestServer.listen(8000, "0.0.0.0");
 
-        controllerTestServer = fastify();
+        controllerTestServer = fastify({ forceCloseConnections: true });
         controllerTestServer.get("/v2/brokers/tables", (req, res) => {
             controllerHandlerHeaders(req.headers);
             const r = Buffer.from(
@@ -34,9 +31,15 @@ describe("ConnectionFactory", () => {
         await controllerTestServer.listen(9000, "0.0.0.0");
     });
 
-    afterEach(async () => {
+    afterAll(async () => {
         await brokerTestServer.close();
         await controllerTestServer.close();
+    });
+
+    beforeEach(async () => {
+        brokerHandlerBody.mockClear();
+        brokerHandlerHeaders.mockClear();
+        controllerHandlerHeaders.mockClear();
     });
 
     describe("fromController method", () => {

--- a/src/connection-factory.ts
+++ b/src/connection-factory.ts
@@ -1,12 +1,12 @@
 import { Connection } from "./connection";
 import { SimpleBrokerSelector } from "./simple-broker-selector";
-import { JsonBrokerClientTransport } from "./json-broker-client-transport";
-import axios from "axios";
-import { JsonControllerClientTransport } from "./json-controller-client-transport";
+import { HttpPostFn, JsonBrokerClientTransport } from "./json-broker-client-transport";
+import { HttpGetFn, JsonControllerClientTransport } from "./json-controller-client-transport";
 import { ControllerBasedBrokerSelector } from "./controller-based-broker-selector";
 import { SelectorUpdaterPeriodic } from "./selector-updater-periodic";
 import { Logger } from "./logger.interface";
 import { dummyLogger } from "./dummy-logger";
+import { request } from "undici";
 
 export type FromHostListOptions = {
     /**
@@ -43,6 +43,23 @@ const fromControllerDefaultOptions: FromControllerOptions = {
     brokerUpdateFreqMs: 1000,
 };
 
+const getFn: HttpGetFn = async (url: string, options: { headers: Record<string, string> }) => {
+    const { statusCode, body } = await request(url, { ...options });
+    const data = await body.json();
+    return { data, status: statusCode };
+};
+
+const postFn: HttpPostFn = async (url: string, data: object, options: { headers: Record<string, string> }) => {
+    const reqBody = JSON.stringify(data);
+    const { statusCode, body } = await request(url, {
+        ...options,
+        method: "POST",
+        body: reqBody,
+    });
+    const respData = await body.json();
+    return { data: respData, status: statusCode };
+};
+
 /**
  * Creates a connection to a Pinot cluster given its Controller URL.
  * The connection's query selector will periodically fetch table-to-broker mapping from via the Controller API.
@@ -57,13 +74,13 @@ async function fromController(
     const actualOptions = Object.assign({}, fromControllerDefaultOptions, options);
     const controllerTransport = new JsonControllerClientTransport(
         controllerAddress,
-        axios.get,
+        getFn,
         actualOptions.controllerReqHeaders
     );
     const brokerSelector = new ControllerBasedBrokerSelector(controllerTransport, actualOptions.logger);
     await brokerSelector.setup();
     const updater = new SelectorUpdaterPeriodic(brokerSelector, actualOptions.brokerUpdateFreqMs, actualOptions.logger);
-    const brokerTransport = new JsonBrokerClientTransport(axios.post, actualOptions.brokerReqHeaders);
+    const brokerTransport = new JsonBrokerClientTransport(postFn, actualOptions.brokerReqHeaders);
     return new Connection(brokerSelector, brokerTransport, actualOptions.logger, updater);
 }
 
@@ -75,7 +92,7 @@ async function fromController(
 function fromHostList(brokerAddresses: string[], options: Partial<FromHostListOptions> = {}): Connection {
     const actualOptions = Object.assign({}, fromHostListDefaultOptions, options);
     const brokerSelector = new SimpleBrokerSelector(brokerAddresses);
-    const transport = new JsonBrokerClientTransport(axios.post, actualOptions.brokerReqHeaders);
+    const transport = new JsonBrokerClientTransport(postFn, actualOptions.brokerReqHeaders);
     return new Connection(brokerSelector, transport, actualOptions.logger);
 }
 

--- a/src/http-client.interface.ts
+++ b/src/http-client.interface.ts
@@ -1,0 +1,38 @@
+/**
+ * HttpClient interface can be used for providing a custom client responsible
+ * for executing GET and POST requests against Pinot Controllers and Brokers.
+ */
+export interface HttpClient {
+    /**
+     * Executes a HTTP GET request at a specified url.
+     * Used for sending requests to Pinot Controllers.
+     */
+    get: <T>(
+        url: string,
+        options: {
+            headers: Record<string, string>;
+        }
+    ) => Promise<HttpClientResponse<T>>;
+    /**
+     * Executes a HTTP POST request at a specified url
+     * Used for querying Pinot Brokers.
+     */
+    post: <T>(
+        url: string,
+        data: object,
+        options: {
+            headers: Record<string, string>;
+        }
+    ) => Promise<HttpClientResponse<T>>;
+}
+
+export interface HttpClientResponse<T> {
+    /**
+     * Parsed data from the HTTP response body
+     */
+    data: T;
+    /**
+     * HTTP response status code
+     */
+    status: number;
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,4 @@
 export { Connection } from "./connection";
 export { ConnectionFactory, FromHostListOptions, FromControllerOptions } from "./connection-factory";
+export { HttpClient, HttpClientResponse } from "./http-client.interface";
 export * from "./broker-response.types";

--- a/src/json-broker-client-transport.spec.ts
+++ b/src/json-broker-client-transport.spec.ts
@@ -1,4 +1,3 @@
-import { AxiosError } from "axios";
 import { JsonBrokerClientTransport } from "./json-broker-client-transport";
 
 describe("JsonBrokerClientTransport class", () => {
@@ -7,7 +6,7 @@ describe("JsonBrokerClientTransport class", () => {
         mockHttpPostFn.mockClear();
     });
     it("should call the HttpPostFn", async () => {
-        mockHttpPostFn.mockResolvedValueOnce({ data: {} });
+        mockHttpPostFn.mockResolvedValueOnce({ data: {}, status: 200 });
         const transport = new JsonBrokerClientTransport(mockHttpPostFn, {});
         await transport.executeQuery("addr:8000", "query");
         expect(mockHttpPostFn).toHaveBeenCalledTimes(1);
@@ -22,7 +21,7 @@ describe("JsonBrokerClientTransport class", () => {
         );
     });
     it("should add custom request headers", async () => {
-        mockHttpPostFn.mockResolvedValueOnce({ data: {} });
+        mockHttpPostFn.mockResolvedValueOnce({ data: {}, status: 200 });
         const transport = new JsonBrokerClientTransport(mockHttpPostFn, { foo: "bar", boo: "baz" });
         await transport.executeQuery("addr:8000", "query");
         expect(mockHttpPostFn).toHaveBeenCalledTimes(1);
@@ -39,14 +38,13 @@ describe("JsonBrokerClientTransport class", () => {
         );
     });
     it("should throw an error with status code on HTTP error", async () => {
-        const errWithResponse = new AxiosError("message");
-        errWithResponse.response = { status: 500, data: {}, headers: {}, statusText: "", config: {} };
-        mockHttpPostFn.mockRejectedValueOnce(errWithResponse);
+        const response = { status: 500, data: { error: "description" } };
+        mockHttpPostFn.mockResolvedValueOnce(response);
         const transport = new JsonBrokerClientTransport(mockHttpPostFn, {});
         await expect(transport.executeQuery("addr:8000", "query")).rejects.toThrowError("500");
     });
     it("should throw an error with message on other errors", async () => {
-        const errWithMessage = new AxiosError("sample message");
+        const errWithMessage = new Error("sample message");
         mockHttpPostFn.mockRejectedValueOnce(errWithMessage);
         const transport = new JsonBrokerClientTransport(mockHttpPostFn, {});
         await expect(transport.executeQuery("addr:8000", "query")).rejects.toThrowError("sample message");

--- a/src/json-broker-client-transport.spec.ts
+++ b/src/json-broker-client-transport.spec.ts
@@ -1,16 +1,18 @@
+import { mock, mockClear } from "jest-mock-extended";
+import { HttpClient } from "./http-client.interface";
 import { JsonBrokerClientTransport } from "./json-broker-client-transport";
 
 describe("JsonBrokerClientTransport class", () => {
-    const mockHttpPostFn = jest.fn();
+    const mockHttpClient = mock<HttpClient>();
     beforeEach(() => {
-        mockHttpPostFn.mockClear();
+        mockClear(mockHttpClient);
     });
-    it("should call the HttpPostFn", async () => {
-        mockHttpPostFn.mockResolvedValueOnce({ data: {}, status: 200 });
-        const transport = new JsonBrokerClientTransport(mockHttpPostFn, {});
+    it("should call the HttpClient post method", async () => {
+        mockHttpClient.post.mockResolvedValueOnce({ data: {}, status: 200 });
+        const transport = new JsonBrokerClientTransport(mockHttpClient, {});
         await transport.executeQuery("addr:8000", "query");
-        expect(mockHttpPostFn).toHaveBeenCalledTimes(1);
-        expect(mockHttpPostFn).toHaveBeenCalledWith(
+        expect(mockHttpClient.post).toHaveBeenCalledTimes(1);
+        expect(mockHttpClient.post).toHaveBeenCalledWith(
             "http://addr:8000/query/sql",
             { sql: "query" },
             {
@@ -21,11 +23,11 @@ describe("JsonBrokerClientTransport class", () => {
         );
     });
     it("should add custom request headers", async () => {
-        mockHttpPostFn.mockResolvedValueOnce({ data: {}, status: 200 });
-        const transport = new JsonBrokerClientTransport(mockHttpPostFn, { foo: "bar", boo: "baz" });
+        mockHttpClient.post.mockResolvedValueOnce({ data: {}, status: 200 });
+        const transport = new JsonBrokerClientTransport(mockHttpClient, { foo: "bar", boo: "baz" });
         await transport.executeQuery("addr:8000", "query");
-        expect(mockHttpPostFn).toHaveBeenCalledTimes(1);
-        expect(mockHttpPostFn).toHaveBeenCalledWith(
+        expect(mockHttpClient.post).toHaveBeenCalledTimes(1);
+        expect(mockHttpClient.post).toHaveBeenCalledWith(
             "http://addr:8000/query/sql",
             { sql: "query" },
             {
@@ -39,14 +41,14 @@ describe("JsonBrokerClientTransport class", () => {
     });
     it("should throw an error with status code on HTTP error", async () => {
         const response = { status: 500, data: { error: "description" } };
-        mockHttpPostFn.mockResolvedValueOnce(response);
-        const transport = new JsonBrokerClientTransport(mockHttpPostFn, {});
+        mockHttpClient.post.mockResolvedValueOnce(response);
+        const transport = new JsonBrokerClientTransport(mockHttpClient, {});
         await expect(transport.executeQuery("addr:8000", "query")).rejects.toThrowError("500");
     });
     it("should throw an error with message on other errors", async () => {
         const errWithMessage = new Error("sample message");
-        mockHttpPostFn.mockRejectedValueOnce(errWithMessage);
-        const transport = new JsonBrokerClientTransport(mockHttpPostFn, {});
+        mockHttpClient.post.mockRejectedValueOnce(errWithMessage);
+        const transport = new JsonBrokerClientTransport(mockHttpClient, {});
         await expect(transport.executeQuery("addr:8000", "query")).rejects.toThrowError("sample message");
     });
 });

--- a/src/json-broker-client-transport.ts
+++ b/src/json-broker-client-transport.ts
@@ -1,23 +1,16 @@
 import { BrokerClientTransport } from "./broker-client-transport.interface";
 import { BrokerResponse } from "./broker-response.types";
+import { HttpClient } from "./http-client.interface";
 import { PinotClientError } from "./pinot-client-error";
 import { withProtocol } from "./url";
 
-export type HttpPostFn = <T>(
-    url: string,
-    data: object,
-    options: {
-        headers: Record<string, string>;
-    }
-) => Promise<{ data: T; status: number }>;
-
 export class JsonBrokerClientTransport implements BrokerClientTransport {
-    constructor(private readonly httpPost: HttpPostFn, private readonly reqHeaders: Record<string, string>) {}
+    constructor(private readonly client: HttpClient, private readonly reqHeaders: Record<string, string>) {}
     public async executeQuery(brokerAddress: string, query: string) {
         try {
             const url = withProtocol(brokerAddress) + "/query/sql";
             const body = { sql: query };
-            const { data, status } = await this.httpPost<BrokerResponse>(url, body, {
+            const { data, status } = await this.client.post<BrokerResponse>(url, body, {
                 headers: {
                     ...this.reqHeaders,
                     "Content-Type": "application/json; charset=utf-8",

--- a/src/json-controller-client-transport.spec.ts
+++ b/src/json-controller-client-transport.spec.ts
@@ -1,16 +1,18 @@
+import { mock, mockClear } from "jest-mock-extended";
+import { HttpClient } from "./http-client.interface";
 import { JsonControllerClientTransport } from "./json-controller-client-transport";
 
 describe("JsonControllerClientTransport class", () => {
-    const mockHttpGetFn = jest.fn();
+    const mockHttpClient = mock<HttpClient>();
     beforeEach(() => {
-        mockHttpGetFn.mockClear();
+        mockClear(mockHttpClient);
     });
-    it("should call the HttpGetFn", async () => {
-        mockHttpGetFn.mockResolvedValueOnce({ data: {}, status: 200 });
-        const transport = new JsonControllerClientTransport("controller:9000", mockHttpGetFn, {});
+    it("should call the HttpClient get method", async () => {
+        mockHttpClient.get.mockResolvedValueOnce({ data: {}, status: 200 });
+        const transport = new JsonControllerClientTransport("controller:9000", mockHttpClient, {});
         const r = await transport.getTableToBrokerMapping();
-        expect(mockHttpGetFn).toHaveBeenCalledTimes(1);
-        expect(mockHttpGetFn).toHaveBeenCalledWith("http://controller:9000/v2/brokers/tables?state=ONLINE", {
+        expect(mockHttpClient.get).toHaveBeenCalledTimes(1);
+        expect(mockHttpClient.get).toHaveBeenCalledWith("http://controller:9000/v2/brokers/tables?state=ONLINE", {
             headers: {
                 "Content-Type": "application/json; charset=utf-8",
             },
@@ -18,11 +20,11 @@ describe("JsonControllerClientTransport class", () => {
         expect(r).toEqual({});
     });
     it("should add custom request headers", async () => {
-        mockHttpGetFn.mockResolvedValueOnce({ data: {}, status: 200 });
-        const transport = new JsonControllerClientTransport("controller:9000", mockHttpGetFn, { key: "val" });
+        mockHttpClient.get.mockResolvedValueOnce({ data: {}, status: 200 });
+        const transport = new JsonControllerClientTransport("controller:9000", mockHttpClient, { key: "val" });
         const r = await transport.getTableToBrokerMapping();
-        expect(mockHttpGetFn).toHaveBeenCalledTimes(1);
-        expect(mockHttpGetFn).toHaveBeenCalledWith("http://controller:9000/v2/brokers/tables?state=ONLINE", {
+        expect(mockHttpClient.get).toHaveBeenCalledTimes(1);
+        expect(mockHttpClient.get).toHaveBeenCalledWith("http://controller:9000/v2/brokers/tables?state=ONLINE", {
             headers: {
                 key: "val",
                 "Content-Type": "application/json; charset=utf-8",
@@ -32,14 +34,14 @@ describe("JsonControllerClientTransport class", () => {
     });
     it("should throw an error with status code on HTTP error", async () => {
         const response = { status: 503, data: {} };
-        mockHttpGetFn.mockResolvedValueOnce(response);
-        const transport = new JsonControllerClientTransport("addr:9000", mockHttpGetFn, {});
+        mockHttpClient.get.mockResolvedValueOnce(response);
+        const transport = new JsonControllerClientTransport("addr:9000", mockHttpClient, {});
         await expect(transport.getTableToBrokerMapping()).rejects.toThrowError("503");
     });
     it("should throw an error with message on other errors", async () => {
         const errWithMessage = new Error("sample message");
-        mockHttpGetFn.mockRejectedValueOnce(errWithMessage);
-        const transport = new JsonControllerClientTransport("addr:9000", mockHttpGetFn, {});
+        mockHttpClient.get.mockRejectedValueOnce(errWithMessage);
+        const transport = new JsonControllerClientTransport("addr:9000", mockHttpClient, {});
         await expect(transport.getTableToBrokerMapping()).rejects.toThrowError("sample message");
     });
 });

--- a/src/json-controller-client-transport.spec.ts
+++ b/src/json-controller-client-transport.spec.ts
@@ -1,4 +1,3 @@
-import { AxiosError } from "axios";
 import { JsonControllerClientTransport } from "./json-controller-client-transport";
 
 describe("JsonControllerClientTransport class", () => {
@@ -7,7 +6,7 @@ describe("JsonControllerClientTransport class", () => {
         mockHttpGetFn.mockClear();
     });
     it("should call the HttpGetFn", async () => {
-        mockHttpGetFn.mockResolvedValueOnce({ data: {} });
+        mockHttpGetFn.mockResolvedValueOnce({ data: {}, status: 200 });
         const transport = new JsonControllerClientTransport("controller:9000", mockHttpGetFn, {});
         const r = await transport.getTableToBrokerMapping();
         expect(mockHttpGetFn).toHaveBeenCalledTimes(1);
@@ -19,7 +18,7 @@ describe("JsonControllerClientTransport class", () => {
         expect(r).toEqual({});
     });
     it("should add custom request headers", async () => {
-        mockHttpGetFn.mockResolvedValueOnce({ data: {} });
+        mockHttpGetFn.mockResolvedValueOnce({ data: {}, status: 200 });
         const transport = new JsonControllerClientTransport("controller:9000", mockHttpGetFn, { key: "val" });
         const r = await transport.getTableToBrokerMapping();
         expect(mockHttpGetFn).toHaveBeenCalledTimes(1);
@@ -32,14 +31,13 @@ describe("JsonControllerClientTransport class", () => {
         expect(r).toEqual({});
     });
     it("should throw an error with status code on HTTP error", async () => {
-        const errWithResponse = new AxiosError("message");
-        errWithResponse.response = { status: 503, data: {}, headers: {}, statusText: "", config: {} };
-        mockHttpGetFn.mockRejectedValueOnce(errWithResponse);
+        const response = { status: 503, data: {} };
+        mockHttpGetFn.mockResolvedValueOnce(response);
         const transport = new JsonControllerClientTransport("addr:9000", mockHttpGetFn, {});
         await expect(transport.getTableToBrokerMapping()).rejects.toThrowError("503");
     });
     it("should throw an error with message on other errors", async () => {
-        const errWithMessage = new AxiosError("sample message");
+        const errWithMessage = new Error("sample message");
         mockHttpGetFn.mockRejectedValueOnce(errWithMessage);
         const transport = new JsonControllerClientTransport("addr:9000", mockHttpGetFn, {});
         await expect(transport.getTableToBrokerMapping()).rejects.toThrowError("sample message");

--- a/src/json-controller-client-transport.ts
+++ b/src/json-controller-client-transport.ts
@@ -3,7 +3,7 @@ import { ControllerResponse } from "./controller-response";
 import { PinotClientError } from "./pinot-client-error";
 import { withProtocol } from "./url";
 
-export type HttpGetFn<T> = (
+export type HttpGetFn = <T>(
     url: string,
     options: {
         headers: Record<string, string>;
@@ -13,12 +13,12 @@ export type HttpGetFn<T> = (
 export class JsonControllerClientTransport implements ControllerClientTransport {
     constructor(
         private readonly controllerAddress: string,
-        private readonly httpGet: HttpGetFn<ControllerResponse>,
+        private readonly httpGet: HttpGetFn,
         private readonly reqHeaders: Record<string, string>
     ) {}
     public async getTableToBrokerMapping() {
         try {
-            const { data } = await this.httpGet(
+            const { data, status } = await this.httpGet<ControllerResponse>(
                 withProtocol(this.controllerAddress) + "/v2/brokers/tables?state=ONLINE",
                 {
                     headers: {
@@ -27,13 +27,12 @@ export class JsonControllerClientTransport implements ControllerClientTransport 
                     },
                 }
             );
+            if (status !== 200) {
+                throw new PinotClientError("Controller responded with HTTP status code: " + status);
+            }
             return data;
         } catch (e) {
-            if (e.response) {
-                throw new PinotClientError("Controller responded with HTTP status code: " + e.response.status);
-            } else {
-                throw new PinotClientError("An error occurred when sending request to the controller: " + e.message);
-            }
+            throw new PinotClientError("An error occurred when sending request to the controller: " + e.message);
         }
     }
 }

--- a/src/json-controller-client-transport.ts
+++ b/src/json-controller-client-transport.ts
@@ -1,24 +1,18 @@
 import { ControllerClientTransport } from "./controller-client-transport.interface";
 import { ControllerResponse } from "./controller-response";
+import { HttpClient } from "./http-client.interface";
 import { PinotClientError } from "./pinot-client-error";
 import { withProtocol } from "./url";
-
-export type HttpGetFn = <T>(
-    url: string,
-    options: {
-        headers: Record<string, string>;
-    }
-) => Promise<{ data: T; status: number }>;
 
 export class JsonControllerClientTransport implements ControllerClientTransport {
     constructor(
         private readonly controllerAddress: string,
-        private readonly httpGet: HttpGetFn,
+        private readonly client: HttpClient,
         private readonly reqHeaders: Record<string, string>
     ) {}
     public async getTableToBrokerMapping() {
         try {
-            const { data, status } = await this.httpGet<ControllerResponse>(
+            const { data, status } = await this.client.get<ControllerResponse>(
                 withProtocol(this.controllerAddress) + "/v2/brokers/tables?state=ONLINE",
                 {
                     headers: {

--- a/src/undici-http-client.ts
+++ b/src/undici-http-client.ts
@@ -1,0 +1,30 @@
+import { Agent, request } from "undici";
+import { HttpClient } from "./http-client.interface";
+
+export class UndiciHttpClient implements HttpClient {
+    private agent: Agent;
+    constructor() {
+        this.agent = new Agent({ pipelining: 1 });
+    }
+    public async post(url: string, data: object, options: { headers: Record<string, string> }) {
+        const reqBody = JSON.stringify(data);
+        const { statusCode, body } = await request(url, {
+            ...options,
+            dispatcher: this.agent,
+            method: "POST",
+            body: reqBody,
+        });
+        const respData = await body.json();
+        return { data: respData, status: statusCode };
+    }
+    public async get(
+        url: string,
+        options: {
+            headers: Record<string, string>;
+        }
+    ) {
+        const { statusCode, body } = await request(url, { ...options, dispatcher: this.agent });
+        const data = await body.json();
+        return { data, status: statusCode };
+    }
+}


### PR DESCRIPTION
This PR removes the `axios` dependency and replaces it with `undici`. On top of that, it enables the users to provide a custom HTTP client implementation via the `customHttpClient` options key.

Resolves #16 